### PR TITLE
DTSPO-17435 Removing old virtual network peers

### DIFF
--- a/virtual-network-peering.tf
+++ b/virtual-network-peering.tf
@@ -4,21 +4,9 @@ data "azurerm_virtual_network" "hmcts-hub-prod-int" {
   provider            = azurerm.prod_peering
 }
 
-data "azurerm_virtual_network" "ukw-hub-prod-int" {
-  name                = "ukw-hub-prod-int"
-  resource_group_name = "ukw-hub-prod-int"
-  provider            = azurerm.prod_peering
-}
-
 data "azurerm_virtual_network" "hmcts-hub-nonprodi" {
   name                = "hmcts-hub-nonprodi"
   resource_group_name = "hmcts-hub-nonprodi"
-  provider            = azurerm.nonprod_peering
-}
-
-data "azurerm_virtual_network" "ukw-hub-nonprodi" {
-  name                = "ukw-hub-nonprodi"
-  resource_group_name = "ukw-hub-nonprodi"
   provider            = azurerm.nonprod_peering
 }
 
@@ -37,9 +25,7 @@ data "azurerm_virtual_network" "core-infra-vnet-mgmt" {
 locals {
   hubs = {
     "hmcts-hub-prod-int"   = data.azurerm_virtual_network.hmcts-hub-prod-int.id
-    "ukw-hub-prod-int"     = data.azurerm_virtual_network.ukw-hub-prod-int.id
     "hmcts-hub-nonprodi"   = data.azurerm_virtual_network.hmcts-hub-nonprodi.id
-    "ukw-hub-nonprodi"     = data.azurerm_virtual_network.ukw-hub-nonprodi.id
     "hmcts-hub-sbox-int"   = data.azurerm_virtual_network.hmcts-hub-sbox-int.id
     "core-infra-vnet-mgmt" = data.azurerm_virtual_network.core-infra-vnet-mgmt.id
   }
@@ -63,28 +49,10 @@ resource "azurerm_virtual_network_peering" "hmcts-hub-prod-int_TO_vnet" {
   allow_forwarded_traffic   = true
 }
 
-resource "azurerm_virtual_network_peering" "ukw-hub-prod-int_TO_vnet" {
-  name                      = "ukw-hub-prod-int-TO-${var.vnet_name}"
-  resource_group_name       = data.azurerm_virtual_network.ukw-hub-prod-int.resource_group_name
-  virtual_network_name      = data.azurerm_virtual_network.ukw-hub-prod-int.name
-  remote_virtual_network_id = azurerm_virtual_network.vnet.id
-  provider                  = azurerm.prod_peering
-  allow_forwarded_traffic   = true
-}
-
 resource "azurerm_virtual_network_peering" "hmcts_hub_nonprodi_TO_vnet" {
   name                      = "hmcts-hub-nonprodi-TO-${var.vnet_name}"
   resource_group_name       = data.azurerm_virtual_network.hmcts-hub-nonprodi.resource_group_name
   virtual_network_name      = data.azurerm_virtual_network.hmcts-hub-nonprodi.name
-  remote_virtual_network_id = azurerm_virtual_network.vnet.id
-  provider                  = azurerm.nonprod_peering
-  allow_forwarded_traffic   = true
-}
-
-resource "azurerm_virtual_network_peering" "ukw_hub_nonprodi_TO_vnet" {
-  name                      = "ukw-hub-nonprodi-TO-${var.vnet_name}"
-  resource_group_name       = data.azurerm_virtual_network.ukw-hub-nonprodi.resource_group_name
-  virtual_network_name      = data.azurerm_virtual_network.ukw-hub-nonprodi.name
   remote_virtual_network_id = azurerm_virtual_network.vnet.id
   provider                  = azurerm.nonprod_peering
   allow_forwarded_traffic   = true


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17435

### Change description ###

removing Virtual network peers as these virtual networks no longer exist

https://dev.azure.com/hmcts/Video%20Hearings/_build/results?buildId=558707&view=logs&j=40e13646-3129-5219-0b49-19adede65ae0&t=2aaebf56-a668-5034-0b31-f71c55cca4ce